### PR TITLE
fix!: remove @babel/eslint-parser and @babel/eslint-plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,4 @@
 import js from '@eslint/js';
-import babelParser from '@babel/eslint-parser';
 
 export default [
 	js.configs.recommended,
@@ -13,7 +12,6 @@ export default [
 	{
 		files: ['**/*.mjs', 'packages/*/src/**/*.js'],
 		languageOptions: {
-			parser: babelParser,
 			sourceType: 'module',
 		},
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,49 +80,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/eslint-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.29.7.tgz",
-      "integrity": "sha512-zxt+UJTOMKvUt3yOg+D58MLuz334pHp93qifMFcjIIO+9hN6t+ufw2gi7vDPMpxvfnHRR+3VVXvIjineCcgyXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "node_modules/@babel/eslint-parser/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@babel/eslint-plugin": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.29.7.tgz",
-      "integrity": "sha512-9qag/N0IHYLNf0nCNvHctNGBpoY4Idr7JkPeYUf2p5J9UpvHpd+Xx6VGjHDhJKmueVBa4/cq6MPl3uxj6/8knw==",
-      "license": "MIT",
-      "dependencies": {
-        "eslint-rule-composer": "^0.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/eslint-parser": "^7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
     "node_modules/@babel/generator": {
       "version": "7.29.8",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
@@ -1743,37 +1700,6 @@
         "@emnapi/core": "^1.1.0",
         "@emnapi/runtime": "^1.1.0",
         "@tybys/wasm-util": "^0.9.0"
-      }
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
-      "license": "MIT",
-      "dependencies": {
-        "eslint-scope": "5.1.1"
-      }
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5985,15 +5911,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-rule-composer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
-      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -12076,7 +11993,6 @@
       "version": "5.1.3",
       "license": "ISC",
       "dependencies": {
-        "@babel/eslint-plugin": "^7.25.9",
         "@bluecateng/eslint-plugin": "^5.1.3",
         "@eslint/js": "^9.3.0",
         "eslint-config-prettier": "^10.0.1",
@@ -12173,7 +12089,6 @@
       "version": "5.1.4",
       "license": "ISC",
       "dependencies": {
-        "@babel/eslint-parser": "^7.15.8",
         "@bluecateng/eslint-config-core": "^5.1.3",
         "@bluecateng/eslint-plugin": "^5.1.3",
         "eslint-plugin-jest": "^29.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,6 @@
     "README.md"
   ],
   "dependencies": {
-    "@babel/eslint-plugin": "^7.25.9",
     "@bluecateng/eslint-plugin": "^5.1.3",
     "@eslint/js": "^9.3.0",
     "eslint-config-prettier": "^10.0.1",

--- a/packages/core/src/main.js
+++ b/packages/core/src/main.js
@@ -1,13 +1,12 @@
 import js from '@eslint/js';
 import prettierConfig from 'eslint-config-prettier';
-import babelPlugin from '@babel/eslint-plugin';
 import importPlugin from 'eslint-plugin-import';
 import promisePlugin from 'eslint-plugin-promise';
 import blueCatEngPlugin from '@bluecateng/eslint-plugin';
 import globals from 'globals';
 
 export default {
-	plugins: {'@bluecateng': blueCatEngPlugin, '@babel': babelPlugin, import: importPlugin, promise: promisePlugin},
+	plugins: {'@bluecateng': blueCatEngPlugin, import: importPlugin, promise: promisePlugin},
 	languageOptions: {
 		globals: {
 			...globals.node,
@@ -58,9 +57,8 @@ export default {
 		yoda: ['warn', 'never', {exceptRange: true}],
 		'no-console': 'off',
 		'no-control-regex': 'off',
-		'no-unused-expressions': 'off',
+		'no-unused-expressions': 'warn',
 		'no-useless-escape': 'off',
-		'@babel/no-unused-expressions': 'warn',
 		'import/export': 'error',
 		'import/extensions': ['warn', 'ignorePackages', {js: 'never'}],
 		'import/newline-after-import': 'warn',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,7 +20,6 @@
     "README.md"
   ],
   "dependencies": {
-    "@babel/eslint-parser": "^7.15.8",
     "@bluecateng/eslint-config-core": "^5.1.3",
     "@bluecateng/eslint-plugin": "^5.1.3",
     "eslint-plugin-jest": "^29.0.1",

--- a/packages/react/src/main.js
+++ b/packages/react/src/main.js
@@ -4,19 +4,14 @@ import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 import blueCatEngPlugin from '@bluecateng/eslint-plugin';
 import blueCatEngCore from '@bluecateng/eslint-config-core';
-import babelParser from '@babel/eslint-parser';
 
 export default {
 	plugins: {...blueCatEngCore.plugins, jest: jestPlugin, react: reactPlugin, 'react-hooks': reactHooksPlugin},
 	languageOptions: {
-		parser: babelParser,
 		sourceType: 'module',
 		parserOptions: {
 			ecmaFeatures: {
 				jsx: true,
-			},
-			babelOptions: {
-				rootMode: 'upward',
 			},
 		},
 		globals: {


### PR DESCRIPTION
They are no longer required to parse JSX under ESLint 9 (espree supports JSX natively), so drop the extra dependencies and the now-unused babelOptions parser option.

BREAKING CHANGE: @bluecateng/eslint-config-react and @bluecateng/eslint-config-core no longer configure a Babel-aware parser or the @babel/no-unused-expressions rule. JSX continues to work via espree's native JSX support, but non-standard/experimental syntax that only Babel understands (e.g. do-expressions, decorators) will now fail to parse. Consumers relying on such syntax must configure their own parser (e.g. @babel/eslint-parser) for the affected files.